### PR TITLE
perf(polars): fuse the minmax line kernel and parallelise arg_min_max across windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,12 @@ jobs:
       - name: Install Python tooling
         run: uv sync --locked --no-install-package flexviz-polars
 
+      # Keep in step with PY_SOURCES in the Makefile.
       - name: black
-        run: uv run --no-sync black --check flexviz tests
+        run: uv run --no-sync black --check flexviz tests flexviz_polars
 
       - name: ruff
-        run: uv run --no-sync ruff check flexviz tests
+        run: uv run --no-sync ruff check flexviz tests flexviz_polars
 
       # rustfmt.toml uses group_imports/imports_granularity, which are
       # nightly-only. rustup auto-installs the toolchain pinned in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Lint
         run: |
-          uv run --no-sync black --check flexviz tests
-          uv run --no-sync ruff check flexviz tests
+          uv run --no-sync black --check flexviz tests flexviz_polars
+          uv run --no-sync ruff check flexviz tests flexviz_polars
 
       - name: Tests
         run: uv run --no-sync pytest tests flexviz_polars/tests -q

--- a/Architecture.md
+++ b/Architecture.md
@@ -17,7 +17,7 @@
 
 => SPEC is key to all of this
 
-- **Rust plugin** — `flexviz_polars` crate exposes `every_nth`, `arg_min_max`, `fixed_hist`, `fixed_hist2d`, `fixed_hist2d_reduce`, and `fpcs` / `_fpcs_line` kernels via `pl.Expr.flexviz` namespace; single-pass, no `len()` expression dependency, enabling N grouped sub-traces to parallelize on one scan. The hist kernels are rayon-parallel on a dedicated pool sized from `POLARS_MAX_THREADS`, with a scalar fallback that produces identical counts
+- **Rust plugin** — `flexviz_polars` crate exposes `every_nth`, `arg_min_max`, `minmax_line`, `fixed_hist`, `fixed_hist2d`, `fixed_hist2d_reduce`, and `fpcs` / `_fpcs_line` kernels via `pl.Expr.flexviz` namespace; single-pass, no `len()` expression dependency, enabling N grouped sub-traces to parallelize on one scan. The hist and argmin/argmax kernels are rayon-parallel on a dedicated pool sized from `POLARS_MAX_THREADS`, with serial fallbacks that produce identical output
 - **Grouped traces** — grouped parents stay logical-only, `LFQueryBuilder` batches shared grouped queries, and group→color mapping persists in client-owned spec state
 - **Multi-column labels and group_by** — `BarPlot.labels`, `PiePlot.labels`, and any trace's `group_by` accept either a string or a list of strings.  Multi-column values are stored as JSON-encoded composite strings (e.g. `'["Europe","Germany"]'`) for legend keys, color-domain mapping, and child-uid stability.  Aggregation uses multi-column `group_by(...)` in Polars; cross-filter emission decomposes the composite back into per-column clauses so the wire format remains a list of `ClauseFilter` objects, never a JSON-encoded string.
 - **Overlay mode** — adapters own cached unfiltered backgrounds per figure, `TraceDelta.layer` carries `bg` / `fg` on the wire, per-trace `overlay_style` controls which layers are emitted, and share/import/export preserve declarative state only
@@ -28,6 +28,7 @@
 Implemented trace types: **LinePlot**, **Histogram**, **BoxPlot**, **BarPlot**, **PiePlot**, **TreeMap**, **Histogram2D**, **GeoHistogram2D**, **CorrHeatmap**, **GeoLine**
 Implemented renderers: **PlotlyAdapter** (line, histogram, box, bar, pie, treemap, heatmap, choroplethmap, scattermap) · **EChartsAdapter** (line, histogram, bar, pie, heatmap)
 => EchartsAdapter is currently deprecated. Very distant future we will update this.
+
 Python ≥ 3.10 · Polars · FastAPI · Uvicorn · Pydantic · flexviz_polars (Rust + maturin)
 
 ---
@@ -410,7 +411,7 @@ fig.add_line(x="timestamp", y="value", name="Sensor A", n_points=1000, add_gaps=
 - `trace_type = "line"`
 - Three downsampling strategies, selected via `downsample` param:
   - **`"nth"`** — uniform stride: uses the `every_nth` Rust kernel (`pl.col(...).filter(vp).flexviz.every_nth(n_points)`) — stride computed inside the kernel, no `len()` expression dependency, enabling N grouped sub-traces to parallelize in one `select()`.
-  - **`"minmax"` (default)** — min-max envelope: splits into `n_points // 2` buckets, returns argmin + argmax of y per bucket via the `arg_min_max` Rust kernel, then gathers x and y at those indices. Preserves extrema and spikes.
+  - **`"minmax"` (default)** — min-max envelope: splits into `n_points // 2` buckets, selects argmin + argmax of y per bucket and gathers x and y at those indices, all in the single `minmax_line` Rust kernel call. Preserves extrema and spikes. One kernel call on purpose: Polars does not CSE opaque plugin expressions, so the earlier two-gather form (`x.gather(idx), y.gather(idx)` over an `arg_min_max` index expression) ran the whole scan twice per trace.
   - **`"fpcs"`** — Feature-Preserving Compensated Sampling: runs the same MinMax bucket pass as `minmax`, then applies a compensation algorithm to carry forward "deferred" extrema across windows. Uses the `_fpcs_line` combined kernel (index selection + gather in one call). `n_points` is a target, not a hard cap; output can reach up to roughly `2 * n_points`.
 - Viewport restriction, ungrouped lines: when the x column has been asserted sorted (`check_sorted` / `assume_sorted`, surfaced via `LFQueryBuilder.is_sorted`, threaded by the engine as `x_sorted`), the viewport becomes a binary-searched, zero-copy `slice(search_sorted(lo), search_sorted(hi) - start)`; otherwise a dtype-aware `is_between` mask. Performance-only choice — `tests/test_trace_line.py::TestSortedViewportSlice` asserts the slice returns exactly what the mask returns. Grouped lines always mask (the filter runs frame-level, before `group_by`).
 - The engine normalizes descending viewport ranges (reversed plotly axes report high-to-low) to `lo <= hi` at ingestion — `_normalize_axis_ranges` in `engine.py` — so neither formulation ever sees a reversed pair.
@@ -664,11 +665,20 @@ flexviz_polars._fpcs_line(x_expr, y_expr, n_points, x_name=None, y_name=None) �
       runs FPCS, gathers both x and y at the selected indices in a single pass.
       Returns Struct{x_name: x_dtype, y_name: y_dtype}. Used by LinePlot with
       downsample="fpcs" to avoid a separate gather step.
+
+flexviz_polars._minmax_line(x_expr, y_expr, n_points, x_name=None, y_name=None) → pl.Expr
+      Combined min-max index-selection + gather kernel, same shape as _fpcs_line.
+      Runs the arg_min_max bucket pass on y, gathers both x and y at the selected
+      indices in one call. Returns Struct{x_name: x_dtype, y_name: y_dtype}. Used
+      by LinePlot with downsample="minmax" (the default). Exists because Polars
+      does not CSE opaque plugin expressions: the two-gather form ran the scan
+      twice per trace. tests/test_trace_line.py pins the one-call plan shape, and
+      TestMinmaxLineDifferential pins bit-identity against the two-gather form.
 ```
 
 **Rust internals** (`src/expressions.rs`):
 - `every_nth` — computes `stride = max(1, len / n_points)`, builds capped gather indices, calls `Series::take()`.
-- `arg_min_max` — reuses internal helpers: `uniform_offsets`,  `simd_argminmax` (SIMD fast path for contiguous numeric types), and `fallback_window_argminmax` (general Series API for non-SIMD/other dtypes). Flattens min+max indices, sorts, deduplicates.
+- `arg_min_max` / `minmax_line` — reuse internal helpers: `uniform_offsets`, `simd_argminmax` (SIMD fast path for contiguous numeric types), and `fallback_window_argminmax` (general Series API for non-SIMD/other dtypes). Flatten min+max indices, sort, deduplicate; `minmax_line` then `take`s x and y at those indices inside the same call. The window scan is rayon-parallel via `par_by_window` on the kernel pool — split by whole windows, so output is bit-identical to the serial path by construction. The split is a trade against the memory-bandwidth ceiling (see its doc comment for the measured numbers): concurrent traces queue through the shared pool, worth ~1.3-1.6x at one trace on a bandwidth-saturated host and bounded at ~-9% for 3-5 concurrent traces, fading by 20.
 - `fpcs` / `_fpcs_line` — shares the `arg_min_max` MinMax bucket pass via `arg_min_max_pairs()`; then `fpcs_compensate()` dispatches per dtype, calling `fpcs_compensate_with_values()` which carries deferred extrema across windows with a dedup guard on every push (prevents duplicate index 0 when the first bucket's argmin equals the start point, and prevents endpoint duplication).
 - `fixed_hist` — dispatches on native dtype via `FixedHistValue` trait (avoids full-column cast); maps each value to a bin with `((v - lo) * scale).floor()` (+ round eps), clamps boundaries. **Rayon-parallel**: null-free contiguous runs are split into work units folded into private per-group count tables and merged by add. Falls back to the scalar single-table loop for chunks with nulls, undispatched dtypes, input below `MIN_PAR` (2^17 rows), or when two private tables exceed the byte budget — counts are identical either way (asserted against an independent Python reference in `test_plugin_functions.py`).
 - `fixed_hist2d` — O(n) 2D binning, same parallel/fallback structure as `fixed_hist` (x/y chunks aligned via `align_chunks_binary`); counts (UInt32) stored row-major. `fixed_hist2d_reduce` (Float64 reductions) remains single-threaded.

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 
+# Every Python source tree in the repo. `flexviz_polars` covers both the plugin's
+# namespace module and its tests, which `make test` already runs.
+PY_SOURCES := flexviz tests flexviz_polars
+
 .PHONY: format
 format:
-	uv run black flexviz tests
-	uv run ruff check flexviz tests
+	uv run black $(PY_SOURCES)
+	uv run ruff check $(PY_SOURCES)
 
 .PHONY: test
 test:

--- a/flexviz/trace/line.py
+++ b/flexviz/trace/line.py
@@ -267,17 +267,15 @@ def _plugin_minmax_agg_expr(
     Splits the (filtered) y-column into ``n_points // 2`` equal buckets and
     gathers x and y at the argmin and argmax positions within each bucket.
     Preserves extrema and spikes that uniform-stride subsampling would miss.
+
+    Index selection and both gathers happen in one kernel call: Polars does not
+    CSE opaque plugin expressions, so the two-gather form
+    (``x.gather(idx), y.gather(idx)``) ran the whole argmin/argmax scan twice.
     """
     y_expr = _apply_viewport(pl.col(y_col), vp)
     x_expr = _apply_viewport(pl.col(x_col), vp)
-    indices = y_expr.flexviz.arg_min_max(n_points)
     return (
-        pl.struct(
-            **{
-                x_col: x_expr.gather(indices),
-                y_col: y_expr.gather(indices),
-            }
-        )
+        _fvp._minmax_line(x_expr, y_expr, n_points, x_name=x_col, y_name=y_col)
         .implode()
         .alias(uid)
     )

--- a/flexviz_polars/benches/bench_argminmax.rs
+++ b/flexviz_polars/benches/bench_argminmax.rs
@@ -11,6 +11,13 @@
 ///    only in partitioning overhead, not data scans).
 /// 3. Data size scaling — measures 1M / 5M / 10M rows at fixed n_buckets=500.
 ///    Confirms linear O(n) growth as expected for a memory-bandwidth-bound kernel.
+/// 4. Concurrent callers — N distinct DRAM-sized columns scanned at once,
+///    serial-per-caller vs pool-split-per-caller on one shared pool. This is the
+///    regime the engine actually runs (N traces batched into one `select`), and
+///    the one the other groups cannot see: a solo call is the sole condition
+///    under which the pool split is unambiguously good. Measured 2026-08-25 on a
+///    bandwidth-saturated Zen 3: the split wins ~1.3-1.6x solo, costs up to ~9%
+///    at 3-5 concurrent callers. This case is where that shows up.
 use argminmax::ArgMinMax;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use rayon::prelude::*;
@@ -207,10 +214,87 @@ fn bench_size_scaling(c: &mut Criterion) {
     group.finish();
 }
 
+// ---------------------------------------------------------------------------
+// 4. Concurrent callers (N traces × one shared kernel pool)
+// ---------------------------------------------------------------------------
+
+/// Mirror of `par_by_window` in expressions.rs: whole windows split into one
+/// contiguous run per pool worker, dispatched through `install` on a shared
+/// pool. The final merge differs trivially from the shipped code (per-part
+/// sort+dedup instead of one merge); the cost is the scan, not the merge.
+fn pooled_path(pool: &rayon::ThreadPool, values: &[f64], offsets: &[(usize, usize)]) -> Vec<u32> {
+    let n_parts = pool.current_num_threads().max(1).min(offsets.len());
+    let windows_per_part = offsets.len().div_ceil(n_parts);
+    let parts: Vec<Vec<u32>> = pool.install(|| {
+        offsets
+            .par_chunks(windows_per_part)
+            .map(|part| simd_serial_path(values, part))
+            .collect()
+    });
+    let mut indices: Vec<u32> = parts.into_iter().flatten().collect();
+    indices.sort_unstable();
+    indices.dedup();
+    indices
+}
+
+fn bench_concurrent_callers(c: &mut Criterion) {
+    // 160 MB per caller: forces DRAM. The `i % 1000` data used above fits in
+    // cache and is exactly the friendly regime that hid the multi-trace
+    // regression this group exists to catch. Odd-constant multiplication mod
+    // 2^23 gives distinct, non-monotonic, branch-hostile values.
+    const N_ROWS: usize = 20_000_000;
+    const N_BUCKETS: usize = 500;
+
+    let offsets = uniform_offsets(N_ROWS, N_BUCKETS);
+    let pool = rayon::ThreadPoolBuilder::new()
+        .build()
+        .expect("failed to build bench pool");
+
+    let mut group = c.benchmark_group("concurrent_callers");
+    group.sample_size(10);
+
+    for n_callers in [1usize, 2, 5] {
+        let columns: Vec<Vec<f64>> = (0..n_callers as u64)
+            .map(|t| {
+                (0..N_ROWS as u64)
+                    .map(|i| (i.wrapping_mul(2654435761).wrapping_add(t * 7919) % (1 << 23)) as f64)
+                    .collect()
+            })
+            .collect();
+        let offsets_ref = &offsets;
+        let pool_ref = &pool;
+
+        group.bench_function(BenchmarkId::new("serial per caller", n_callers), |b| {
+            b.iter(|| {
+                std::thread::scope(|s| {
+                    for col in &columns {
+                        s.spawn(move || simd_serial_path(black_box(col), black_box(offsets_ref)));
+                    }
+                })
+            })
+        });
+
+        group.bench_function(BenchmarkId::new("pool split per caller", n_callers), |b| {
+            b.iter(|| {
+                std::thread::scope(|s| {
+                    for col in &columns {
+                        s.spawn(move || {
+                            pooled_path(pool_ref, black_box(col), black_box(offsets_ref))
+                        });
+                    }
+                })
+            })
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_simd_vs_scalar,
     bench_bucket_scaling,
-    bench_size_scaling
+    bench_size_scaling,
+    bench_concurrent_callers
 );
 criterion_main!(benches);

--- a/flexviz_polars/benches/bench_argminmax.rs
+++ b/flexviz_polars/benches/bench_argminmax.rs
@@ -57,6 +57,35 @@ fn simd_path(values: &[f64], offsets: &[(usize, usize)]) -> Vec<u32> {
     indices
 }
 
+/// Serial SIMD path — mirrors `argminmax_contiguous` in expressions.rs. That is
+/// what each `par_by_window` worker runs, and what the whole kernel runs below
+/// the MIN_PAR threshold, so its cost is the per-worker floor. `simd_path` above
+/// is the parallel shape; keeping both makes the gap between them visible.
+fn simd_serial_path(values: &[f64], offsets: &[(usize, usize)]) -> Vec<u32> {
+    let mut min_indices = Vec::with_capacity(offsets.len());
+    let mut max_indices = Vec::with_capacity(offsets.len());
+    for &(start, len) in offsets {
+        if len == 0 {
+            min_indices.push(None);
+            max_indices.push(None);
+            continue;
+        }
+        let slice = &values[start..start + len];
+        let (min_i, max_i) = slice.argminmax();
+        min_indices.push(Some((start + min_i) as u64));
+        max_indices.push(Some((start + max_i) as u64));
+    }
+    let mut indices: Vec<u32> = min_indices
+        .into_iter()
+        .chain(max_indices)
+        .flatten()
+        .map(|i| i as u32)
+        .collect();
+    indices.sort_unstable();
+    indices.dedup();
+    indices
+}
+
 /// Scalar fallback using manual PartialOrd comparisons (previous implementation).
 fn scalar_path(values: &[f64], offsets: &[(usize, usize)]) -> Vec<u32> {
     let pairs: Vec<(Option<u64>, Option<u64>)> = offsets
@@ -115,6 +144,12 @@ fn bench_simd_vs_scalar(c: &mut Criterion) {
         BenchmarkId::new("simd (argminmax crate)", N_ROWS),
         &(&data, &offsets),
         |b, (data, offsets)| b.iter(|| simd_path(black_box(data), black_box(offsets))),
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("simd serial (shipped)", N_ROWS),
+        &(&data, &offsets),
+        |b, (data, offsets)| b.iter(|| simd_serial_path(black_box(data), black_box(offsets))),
     );
 
     group.bench_with_input(

--- a/flexviz_polars/flexviz_polars/__init__.py
+++ b/flexviz_polars/flexviz_polars/__init__.py
@@ -34,6 +34,22 @@ def _arg_min_max(expr: IntoExprColumn, n_points: int) -> pl.Expr:
     )
 
 
+def _minmax_line(
+    x_expr: "IntoExprColumn",
+    y_expr: "IntoExprColumn",
+    n_points: int,
+    x_name: str | None = None,
+    y_name: str | None = None,
+) -> pl.Expr:
+    return register_plugin_function(
+        args=[x_expr, y_expr],
+        plugin_path=LIB,
+        function_name="minmax_line",
+        kwargs={"n_points": n_points, "x_name": x_name, "y_name": y_name},
+        is_elementwise=False,
+    )
+
+
 def _fpcs_indices(expr: IntoExprColumn, n_points: int) -> pl.Expr:
     return register_plugin_function(
         args=[expr],

--- a/flexviz_polars/src/expressions.rs
+++ b/flexviz_polars/src/expressions.rs
@@ -591,10 +591,13 @@ where
     // huge frame stays serial. n_points defaults to 1000 (500 windows), so this
     // only bites on deliberately degenerate input; split within a window if that
     // ever becomes a real shape.
-    let n_chunks = pool.current_num_threads().max(1).min(offsets.len());
-    let per_chunk = offsets.len().div_ceil(n_chunks);
+    // "part" not "chunk": in this file `chunks` already means the Arrow buffers
+    // backing a ChunkedArray, which are a different thing entirely.
+    let n_parts = pool.current_num_threads().max(1).min(offsets.len());
+    let windows_per_part = offsets.len().div_ceil(n_parts);
 
-    let parts: Vec<ArgMinMaxIdx> = pool.install(|| offsets.par_chunks(per_chunk).map(&f).collect());
+    let parts: Vec<ArgMinMaxIdx> =
+        pool.install(|| offsets.par_chunks(windows_per_part).map(&f).collect());
 
     let mut min_indices = Vec::with_capacity(offsets.len());
     let mut max_indices = Vec::with_capacity(offsets.len());

--- a/flexviz_polars/src/expressions.rs
+++ b/flexviz_polars/src/expressions.rs
@@ -83,6 +83,13 @@ struct ArgMinMaxKwargs {
     n_points: usize,
 }
 
+#[derive(Deserialize)]
+struct MinmaxLineKwargs {
+    n_points: usize,
+    x_name: Option<String>,
+    y_name: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // fpcs
 // ---------------------------------------------------------------------------
@@ -216,6 +223,46 @@ fn arg_min_max(inputs: &[Series], kwargs: ArgMinMaxKwargs) -> PolarsResult<Serie
     let s = &inputs[0];
     let indices = arg_min_max_indices(s, kwargs.n_points)?;
     Ok(UInt32Chunked::from_iter_values(s.name().clone(), indices.into_iter()).into_series())
+}
+
+fn minmax_line_output(inputs: &[Field]) -> PolarsResult<Field> {
+    Ok(Field::new(
+        PlSmallStr::EMPTY,
+        DataType::Struct(vec![inputs[0].clone(), inputs[1].clone()]),
+    ))
+}
+
+/// `arg_min_max` plus both gathers in one call. Exists because Polars does not
+/// CSE opaque plugin expressions: `x.gather(idx)` / `y.gather(idx)` on the same
+/// `arg_min_max` expression runs the whole scan twice (`fpcs_line` predates this
+/// for the same reason).
+#[polars_expr(output_type_func = minmax_line_output)]
+fn minmax_line(inputs: &[Series], kwargs: MinmaxLineKwargs) -> PolarsResult<Series> {
+    polars_ensure!(
+        kwargs.n_points > 0,
+        InvalidOperation: "n_points must be greater than 0"
+    );
+
+    let x = &inputs[0];
+    let y = &inputs[1];
+    polars_ensure!(
+        x.len() == y.len(),
+        ShapeMismatch: "minmax_line: x and y must have the same length"
+    );
+
+    let indices = arg_min_max_indices(y, kwargs.n_points)?;
+    let idx_ca = UInt32Chunked::from_iter_values(PlSmallStr::EMPTY, indices.into_iter());
+    let mut x_taken = x.take(&idx_ca)?;
+    let mut y_taken = y.take(&idx_ca)?;
+    let x_name = output_name(kwargs.x_name, x.name(), "x");
+    let y_name = output_name(kwargs.y_name, y.name(), "y");
+    x_taken.rename(x_name);
+    y_taken.rename(y_name);
+    let len = x_taken.len();
+
+    let out =
+        StructChunked::from_series("minmax_line".into(), len, [&x_taken, &y_taken].into_iter())?;
+    Ok(out.into_series())
 }
 
 fn fpcs_indices_output(inputs: &[Field]) -> PolarsResult<Field> {

--- a/flexviz_polars/src/expressions.rs
+++ b/flexviz_polars/src/expressions.rs
@@ -622,6 +622,19 @@ fn simd_argminmax(s: &Series, offsets: &[(usize, usize)]) -> Option<ArgMinMaxIdx
 /// `par_chunks` rather than a per-window `par_iter`: a few thousand windows as
 /// individual rayon tasks is pure overhead, and neighbouring workers writing
 /// adjacent output slots is false sharing. A contiguous run per worker avoids both.
+///
+/// This is a trade against the memory-bandwidth ceiling, not a free speedup.
+/// Concurrent callers (N traces batched into one `select`) each take the whole
+/// pool, so their scans queue instead of overlapping; whether that beats N
+/// overlapped serial scans depends on how much faster one pool-wide scan is,
+/// which is a property of the host's per-core vs package bandwidth. Measured
+/// 2026-08-25 (100M f64 rows, n_points=1000, fused kernel): on a
+/// bandwidth-saturated Zen 3 the split is worth ~1.3-1.6x at one trace and
+/// costs at most ~9%, peaking at 3-5 concurrent traces and fading to ~2% by 20
+/// as contended installs degrade toward the caller's own thread; on Apple
+/// M-series it wins at every measured trace count. Do not add an
+/// in-flight-count gate: measured twice (2026-08-24), it recovered nothing,
+/// because the first arrivals still take the whole pool.
 fn par_by_window<F>(offsets: &[(usize, usize)], f: F) -> ArgMinMaxIdx
 where
     F: Fn(&[(usize, usize)]) -> ArgMinMaxIdx + Send + Sync,

--- a/flexviz_polars/src/expressions.rs
+++ b/flexviz_polars/src/expressions.rs
@@ -316,8 +316,12 @@ fn arg_min_max_pairs(s: &Series, n_buckets: usize) -> PolarsResult<Vec<(u32, u32
     }
 
     let offsets = uniform_offsets(s.len(), n_buckets.min(s.len()).max(1));
-    let (arg_min_vec, arg_max_vec) =
-        simd_argminmax(s, &offsets).unwrap_or_else(|| fallback_window_argminmax(s, &offsets));
+    // The fallback is the null path, and nulls are common in real signals: one null
+    // in 20M rows drops the whole column here, costing ~12x. It splits by window
+    // like the SIMD paths — each entry carries an absolute `start`, so no cursor to
+    // seed — so it gets the same treatment for free.
+    let (arg_min_vec, arg_max_vec) = simd_argminmax(s, &offsets)
+        .unwrap_or_else(|| par_by_window(&offsets, |o| fallback_window_argminmax(s, o)));
 
     Ok(arg_min_vec
         .into_iter()

--- a/flexviz_polars/src/expressions.rs
+++ b/flexviz_polars/src/expressions.rs
@@ -521,13 +521,13 @@ fn simd_argminmax(s: &Series, offsets: &[(usize, usize)]) -> Option<ArgMinMaxIdx
             if let Ok(ca) = s.$downcast() {
                 if ca.null_count() == 0 {
                     if let Ok(values) = ca.cont_slice() {
-                        return Some(argminmax_contiguous(values, offsets));
+                        return Some(par_by_window(offsets, |o| argminmax_contiguous(values, o)));
                     }
                     let chunks: Vec<_> = ca
                         .downcast_iter()
                         .map(|arr| arr.values().as_slice())
                         .collect();
-                    return Some(argminmax_chunked(&chunks, offsets));
+                    return Some(par_by_window(offsets, |o| argminmax_chunked(&chunks, o)));
                 }
             }
         };
@@ -548,17 +548,61 @@ fn simd_argminmax(s: &Series, offsets: &[(usize, usize)]) -> Option<ArgMinMaxIdx
         if ca.null_count() == 0 {
             if let Ok(values) = ca.cont_slice() {
                 let values = pf16_as_half_slice(values);
-                return Some(argminmax_contiguous(values, offsets));
+                return Some(par_by_window(offsets, |o| argminmax_contiguous(values, o)));
             }
             let chunks: Vec<_> = ca
                 .downcast_iter()
                 .map(|arr| pf16_as_half_slice(arr.values().as_slice()))
                 .collect();
-            return Some(argminmax_chunked(&chunks, offsets));
+            return Some(par_by_window(offsets, |o| argminmax_chunked(&chunks, o)));
         }
     }
 
     None
+}
+
+/// Run `f` over `offsets` on [`kernel_pool`], split into one contiguous run of
+/// windows per worker.
+///
+/// The split is by *window*, never inside one, so every `argminmax()` call sees
+/// exactly the slice it would have seen serially — the result is bit-identical to
+/// the serial path by construction, with no index merging or tie-break logic.
+///
+/// `par_chunks` rather than a per-window `par_iter`: a few thousand windows as
+/// individual rayon tasks is pure overhead, and neighbouring workers writing
+/// adjacent output slots is false sharing. A contiguous run per worker avoids both.
+fn par_by_window<F>(offsets: &[(usize, usize)], f: F) -> ArgMinMaxIdx
+where
+    F: Fn(&[(usize, usize)]) -> ArgMinMaxIdx + Send + Sync,
+{
+    use rayon::prelude::*;
+
+    // Below this the task and merge overhead exceed the scan. Same knob as the
+    // histogram kernels; measured on the same shape.
+    const MIN_PAR: usize = 1 << 17;
+
+    let total: usize = offsets.iter().map(|&(_, len)| len).sum();
+    if total < MIN_PAR || offsets.len() < 2 {
+        return f(offsets);
+    }
+
+    let pool = kernel_pool();
+    // ponytail: parallelism is capped by window count, so a tiny `n_points` over a
+    // huge frame stays serial. n_points defaults to 1000 (500 windows), so this
+    // only bites on deliberately degenerate input; split within a window if that
+    // ever becomes a real shape.
+    let n_chunks = pool.current_num_threads().max(1).min(offsets.len());
+    let per_chunk = offsets.len().div_ceil(n_chunks);
+
+    let parts: Vec<ArgMinMaxIdx> = pool.install(|| offsets.par_chunks(per_chunk).map(&f).collect());
+
+    let mut min_indices = Vec::with_capacity(offsets.len());
+    let mut max_indices = Vec::with_capacity(offsets.len());
+    for (mins, maxs) in parts {
+        min_indices.extend(mins);
+        max_indices.extend(maxs);
+    }
+    (min_indices, max_indices)
 }
 
 fn argminmax_contiguous<T>(values: &[T], offsets: &[(usize, usize)]) -> ArgMinMaxIdx
@@ -590,8 +634,18 @@ where
     let mut max_indices = Vec::with_capacity(offsets.len());
     // Single monotone cursor — advances only when a chunk is fully consumed by a window.
     // Correct because uniform_offsets produces contiguous, non-overlapping windows in order.
+    //
+    // The cursor is seeded from the *first* window rather than assumed to start at
+    // row 0, which is what makes this correct for any contiguous run of windows and
+    // therefore safe to hand a sub-slice of `offsets` (see `par_by_window`).
+    // ponytail: linear scan, chunk counts are small; binary search if that changes.
+    let first_start = offsets.first().map_or(0, |&(start, _)| start);
     let mut chunk_idx = 0usize;
     let mut chunk_pos = 0usize; // global offset of chunks[chunk_idx][0]
+    while chunk_idx < chunks.len() && chunk_pos + chunks[chunk_idx].len() <= first_start {
+        chunk_pos += chunks[chunk_idx].len();
+        chunk_idx += 1;
+    }
 
     for &(window_start, window_len) in offsets {
         if window_len == 0 {

--- a/flexviz_polars/tests/test_plugin_functions.py
+++ b/flexviz_polars/tests/test_plugin_functions.py
@@ -1804,6 +1804,67 @@ class TestArgMinMaxParallel:
         assert _arg_min_max(one, n_points=n_points).to_list() == expected
         assert _arg_min_max(many, n_points=n_points).to_list() == expected
 
+    # -- null fallback -----------------------------------------------------
+    #
+    # `simd_argminmax` requires null_count == 0, so a single null routes the whole
+    # column to `fallback_window_argminmax`. That is also split by window, so these
+    # exercise the parallel fallback rather than the SIMD paths.
+
+    @staticmethod
+    def _expected_with_nulls(values: list[float | None], n_points: int) -> list[int]:
+        n = len(values)
+        n_out = max(min(max(n_points // 2, 1), n), 1)
+        base, remainder = divmod(n, n_out)
+        indices: set[int] = set()
+        start = 0
+        for i in range(n_out):
+            window_len = base + (1 if i < remainder else 0)
+            live = [
+                start + k for k in range(window_len) if values[start + k] is not None
+            ]
+            # An all-null window yields no index at all (both args are None and the
+            # pair is dropped), matching `arg_min_max_pairs`.
+            if live:
+                indices.add(min(live, key=lambda j: values[j]))
+                indices.add(max(live, key=lambda j: values[j]))
+            start += window_len
+        return sorted(indices)
+
+    @pytest.mark.parametrize("n_chunks_in", [1, 5])
+    def test_scattered_nulls_match_oracle(self, n_chunks_in):
+        values: list[float | None] = list(_distinct_values(PAR_ROWS))
+        for i in range(0, PAR_ROWS, 7):  # ~14% nulls, none of them window-aligned
+            values[i] = None
+        if n_chunks_in == 1:
+            s = pl.Series("y", values, dtype=pl.Float64)
+        else:
+            step = PAR_ROWS // n_chunks_in
+            s = pl.concat(
+                [
+                    pl.Series("y", values[a : a + step], dtype=pl.Float64)
+                    for a in range(0, PAR_ROWS, step)
+                ],
+                rechunk=False,
+            )
+        assert s.null_count() > 0 and s.n_chunks() == n_chunks_in
+        assert _arg_min_max(s, n_points=1000).to_list() == self._expected_with_nulls(
+            values, 1000
+        )
+
+    def test_all_null_window_contributes_no_index(self):
+        values: list[float | None] = list(_distinct_values(PAR_ROWS))
+        # 500 windows of 600 rows; blank window 3 entirely.
+        for i in range(3 * 600, 4 * 600):
+            values[i] = None
+        s = pl.Series("y", values, dtype=pl.Float64)
+        result = _arg_min_max(s, n_points=1000).to_list()
+        assert result == self._expected_with_nulls(values, 1000)
+        assert not any(3 * 600 <= i < 4 * 600 for i in result)
+
+    def test_all_null_series(self):
+        s = pl.Series("y", [None] * PAR_ROWS, dtype=pl.Float64)
+        assert _arg_min_max(s, n_points=1000).to_list() == []
+
     def test_window_count_below_worker_count_stays_correct(self):
         """n_points=2 gives one window: below the 2-window floor, so serial."""
         values = _distinct_values(PAR_ROWS)

--- a/flexviz_polars/tests/test_plugin_functions.py
+++ b/flexviz_polars/tests/test_plugin_functions.py
@@ -1728,3 +1728,84 @@ class TestKernelThreadPool:
         assert (
             limited < cores
         ), f"{limited} threads under POLARS_MAX_THREADS=2 on a {cores}-core box"
+
+
+# ---------------------------------------------------------------------------
+# arg_min_max — parallel window path
+#
+# `par_by_window` only engages above MIN_PAR (1 << 17) total rows, so every test
+# above this point exercises the serial path only. These run over that threshold.
+# ---------------------------------------------------------------------------
+
+PAR_ROWS = 300_000  # > MIN_PAR (131_072)
+
+
+def _distinct_values(n: int) -> list[float]:
+    """Distinct, non-monotonic values.
+
+    Multiplication by an odd constant mod 2**23 is a bijection, so no two entries
+    tie. Ties matter: SIMD argminmax may pick any index among equal values, so a
+    tie would make the oracle comparison legitimately ambiguous. 2**23 also keeps
+    every value exact in Float32 and in range for Int32.
+    """
+    return [float((i * 2654435761) % (2**23)) for i in range(n)]
+
+
+def _expected_arg_min_max(values: list[float], n_points: int) -> list[int]:
+    """Independent oracle: pure-Python argmin/argmax per uniform window."""
+    n = len(values)
+    n_out = max(min(max(n_points // 2, 1), n), 1)
+    base, remainder = divmod(n, n_out)
+    indices: set[int] = set()
+    start = 0
+    for i in range(n_out):
+        window_len = base + (1 if i < remainder else 0)
+        if window_len:
+            window = values[start : start + window_len]
+            indices.add(start + min(range(window_len), key=window.__getitem__))
+            indices.add(start + max(range(window_len), key=window.__getitem__))
+        start += window_len
+    return sorted(indices)
+
+
+class TestArgMinMaxParallel:
+    @pytest.mark.parametrize("dtype", [pl.Float64, pl.Float32, pl.Int64, pl.Int32])
+    def test_single_chunk_matches_oracle(self, dtype):
+        values = _distinct_values(PAR_ROWS)
+        s = pl.Series("y", values, dtype=pl.Float64).cast(dtype)
+        assert s.n_chunks() == 1
+        result = _arg_min_max(s, n_points=1000).to_list()
+        assert result == _expected_arg_min_max(s.to_list(), 1000)
+
+    @pytest.mark.parametrize("n_points", [4, 1000, 20_001])
+    def test_multi_chunk_matches_single_chunk(self, n_points):
+        """The per-worker chunk cursor must be seeded from its own first window.
+
+        A worker that inherited a cursor starting at row 0 would mis-locate every
+        window it owns; with a single chunk there is nothing to mis-locate, so this
+        pairing is what catches it.
+        """
+        values = _distinct_values(PAR_ROWS)
+        one = pl.Series("y", values, dtype=pl.Float64)
+        # Deliberately uneven, including length-1 chunks, so a worker's first
+        # window can start mid-chunk and the cursor cannot rely on a uniform stride.
+        bounds = [0, 1, 7919, 100_000, 100_001, 233_333, PAR_ROWS]
+        many = pl.concat(
+            [
+                pl.Series("y", values[a:b], dtype=pl.Float64)
+                for a, b in zip(bounds, bounds[1:])
+            ],
+            rechunk=False,
+        )
+        assert many.n_chunks() == len(bounds) - 1
+        assert many.to_list() == values
+
+        expected = _expected_arg_min_max(values, n_points)
+        assert _arg_min_max(one, n_points=n_points).to_list() == expected
+        assert _arg_min_max(many, n_points=n_points).to_list() == expected
+
+    def test_window_count_below_worker_count_stays_correct(self):
+        """n_points=2 gives one window: below the 2-window floor, so serial."""
+        values = _distinct_values(PAR_ROWS)
+        s = pl.Series("y", values, dtype=pl.Float64)
+        assert _arg_min_max(s, n_points=2).to_list() == _expected_arg_min_max(values, 2)

--- a/flexviz_polars/tests/test_plugin_functions.py
+++ b/flexviz_polars/tests/test_plugin_functions.py
@@ -32,6 +32,14 @@ def _fpcs_line(x: pl.Series, y: pl.Series, n_points: int) -> pl.Series:
     ).to_series()
 
 
+def _minmax_line(x: pl.Series, y: pl.Series, n_points: int) -> pl.Series:
+    return pl.select(
+        flexviz_polars._minmax_line(
+            pl.lit(x), pl.lit(y), n_points, x_name=x.name, y_name=y.name
+        )
+    ).to_series()
+
+
 def _fixed_hist(
     series: pl.Series,
     lo: float,
@@ -1870,3 +1878,126 @@ class TestArgMinMaxParallel:
         values = _distinct_values(PAR_ROWS)
         s = pl.Series("y", values, dtype=pl.Float64)
         assert _arg_min_max(s, n_points=2).to_list() == _expected_arg_min_max(values, 2)
+
+
+# ---------------------------------------------------------------------------
+# minmax_line — differential against the two-gather form
+#
+# `minmax_line` exists because Polars does not CSE opaque plugin expressions:
+# the pre-fusion form `x.gather(idx), y.gather(idx)` ran the whole arg_min_max
+# scan twice per trace. Both formulations are still compiled into the plugin,
+# so the old form is the reference. A differential is stronger than an oracle
+# here: on ties and NaN the SIMD kernel may pick any of several valid indices,
+# which an independent oracle cannot predict, but both formulations run the
+# identical index selection, so equality is exact by construction.
+# ---------------------------------------------------------------------------
+
+
+def _two_gather(x: pl.Series, y: pl.Series, n_points: int) -> pl.Series:
+    """The pre-fusion formulation of the minmax line aggregation."""
+    idx = pl.lit(y).flexviz.arg_min_max(n_points)
+    return pl.select(
+        pl.struct(
+            **{x.name: pl.lit(x).gather(idx), y.name: pl.lit(y).gather(idx)}
+        ).alias("out")
+    ).to_series()
+
+
+def _assert_fused_matches(x: pl.Series, y: pl.Series, n_points: int) -> None:
+    from polars.testing import assert_series_equal
+
+    fused = _minmax_line(x, y, n_points).rename("out")
+    assert_series_equal(fused, _two_gather(x, y, n_points))
+
+
+class TestMinmaxLineDifferential:
+    @pytest.mark.parametrize("n_rows", [1_000, PAR_ROWS])  # serial and parallel paths
+    @pytest.mark.parametrize(
+        "dtype", [pl.Float64, pl.Float32, pl.Float16, pl.Int64, pl.Int32]
+    )
+    def test_dtypes(self, n_rows, dtype):
+        # The f16 cast collapses distinct values into plateaus; for a
+        # differential that is a feature, not a problem (see class comment).
+        y = pl.Series("y", _distinct_values(n_rows), dtype=pl.Float64).cast(dtype)
+        x = pl.Series("x", range(n_rows), dtype=pl.Float64)
+        _assert_fused_matches(x, y, 1000)
+
+    @pytest.mark.parametrize("n_points", [1, 2, 3, 1000, 25_000])
+    def test_n_points_extremes(self, n_points):
+        n = 10_000
+        y = pl.Series("y", _distinct_values(n))
+        x = pl.Series("x", range(n), dtype=pl.Float64)
+        _assert_fused_matches(x, y, n_points)
+
+    def test_plateaus(self):
+        """Ties everywhere: which index wins is kernel-defined, but both forms
+        must pick the same one."""
+        n = 10_000
+        y = pl.Series("y", [float(i // 500) for i in range(n)])
+        x = pl.Series("x", range(n), dtype=pl.Float64)
+        _assert_fused_matches(x, y, 100)
+
+    def test_nan(self):
+        values = _distinct_values(10_000)
+        values[10::100] = [float("nan")] * len(values[10::100])
+        y = pl.Series("y", values)
+        x = pl.Series("x", range(len(values)), dtype=pl.Float64)
+        _assert_fused_matches(x, y, 1000)
+
+    @pytest.mark.parametrize("n_rows", [10_000, PAR_ROWS])
+    def test_y_nulls_route_to_fallback(self, n_rows):
+        values: list[float | None] = list(_distinct_values(n_rows))
+        for i in range(0, n_rows, 7):
+            values[i] = None
+        y = pl.Series("y", values, dtype=pl.Float64)
+        x = pl.Series("x", range(n_rows), dtype=pl.Float64)
+        _assert_fused_matches(x, y, 1000)
+
+    def test_x_nulls_survive_the_gather(self):
+        n = 10_000
+        y = pl.Series("y", _distinct_values(n))
+        x = pl.Series(
+            "x", [None if i % 3 == 0 else float(i) for i in range(n)], dtype=pl.Float64
+        )
+        _assert_fused_matches(x, y, 1000)
+
+    def test_datetime_x(self):
+        from datetime import datetime, timedelta
+
+        n = 10_000
+        t0 = datetime(2026, 1, 1)
+        x = pl.Series("x", [t0 + timedelta(seconds=i) for i in range(n)])
+        y = pl.Series("y", _distinct_values(n))
+        _assert_fused_matches(x, y, 1000)
+
+    def test_multi_chunk(self):
+        values = _distinct_values(PAR_ROWS)
+        bounds = [0, 1, 7919, 100_000, 233_333, PAR_ROWS]
+        y = pl.concat(
+            [
+                pl.Series("y", values[a:b], dtype=pl.Float64)
+                for a, b in zip(bounds, bounds[1:])
+            ],
+            rechunk=False,
+        )
+        x = pl.Series("x", range(PAR_ROWS), dtype=pl.Float64)
+        assert y.n_chunks() == len(bounds) - 1
+        _assert_fused_matches(x, y, 1000)
+
+    def test_empty(self):
+        _assert_fused_matches(
+            pl.Series("x", [], dtype=pl.Float64),
+            pl.Series("y", [], dtype=pl.Float64),
+            1000,
+        )
+
+    def test_single_row(self):
+        _assert_fused_matches(pl.Series("x", [1.0]), pl.Series("y", [2.0]), 1000)
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(Exception, match="same length"):
+            _minmax_line(pl.Series("x", [1.0, 2.0]), pl.Series("y", [1.0]), 10)
+
+    def test_n_points_zero_raises(self):
+        with pytest.raises(Exception, match="greater than 0"):
+            _minmax_line(pl.Series("x", [1.0]), pl.Series("y", [1.0]), 0)

--- a/tests/test_trace_line.py
+++ b/tests/test_trace_line.py
@@ -266,6 +266,24 @@ class TestLinePlotPlugin:
         assert len(update["x"]) <= 20
         assert 10.0 in update["y"].to_list()
 
+    def test_minmax_agg_expr_runs_kernel_once(self):
+        """Pin the fusion: one minmax_line call, no bare arg_min_max.
+
+        Polars does not CSE opaque plugin expressions, so the two-gather form
+        (x.gather(idx), y.gather(idx)) evaluated the whole argmin/argmax scan
+        twice per trace. Output-based tests are blind to that: reverting to the
+        two-gather form changes no result, only the work. The optimized plan is
+        where the property is visible.
+        """
+        from flexviz.trace.line import _plugin_minmax_agg_expr
+
+        lf = pl.DataFrame({"ts": [1.0, 2.0], "val": [3.0, 4.0]}).lazy()
+        plan = lf.select(_plugin_minmax_agg_expr("ts", "val", None, 100, "u")).explain(
+            optimized=True
+        )
+        assert plan.count("minmax_line") == 1
+        assert "arg_min_max" not in plan
+
     def test_fpcs_preserves_spike(self):
         vals = [0.0] * 499 + [1000.0] + [0.0] * 500
         df = pl.DataFrame({"ts": list(range(1000)), "val": vals})


### PR DESCRIPTION
## What

Two performance changes to the default line downsampling path (`downsample="minmax"`), measured together across two hosts:

1. **Fused `minmax_line` kernel.** Polars does not CSE opaque plugin expressions, so the old form (`x.gather(idx), y.gather(idx)` over an `arg_min_max` index expression) ran the whole argmin/argmax scan twice per trace. The new kernel selects indices and gathers both columns in one call (same shape as `fpcs_line`). This is the major performance improvement.
2. **`par_by_window`.** The window scan runs parallel on the plugin's kernel pool, split by whole windows so output is bit-identical to serial by construction. The null-fallback path gets the same treatment.

## Numbers (100M rows, in-memory, kernel select, median)

| traces | main | this PR | speedup |
|---|---|---|---|
| 1 | 35.3 ms | 19.1 ms | 1.8x |
| 5 | 130.9 ms | 94.3 ms | 1.4x |
| 20 | 599 ms | 376 ms | 1.6x |

Ryzen 5950X (DDR4, worst case tested). On an Apple M5 the same shapes run 2 to 6x faster than main. Frame times also become markedly steadier: the two racing scans per trace made main bimodal (100 to 157 ms at 5 traces); fused spread is under 1%.

**The parallel split is a trade-off, not a free win**: on a bandwidth-saturated host it is worth ~1.3-1.6x at one trace and costs at most ~9% at 3-5 concurrent traces, fading to ~2% by 20. Kept because the win exceeds the bounded loss; see the `par_by_window` doc comment for the measured numbers and why an in-flight gate does not work.

## Correctness

- Output is bit-identical to the two-gather form: pinned by `TestMinmaxLineDifferential` (26 cases: dtypes incl. f16, nulls, NaN, ties, multi-chunk, datetime x, empty).
- The one-scan property itself is pinned by a plan-shape test (exactly one `minmax_line`, zero `arg_min_max` in the optimized plan).
- New `concurrent_callers` bench group covers the multi-trace regime the solo benches could not see (which is how the earlier regression slipped through).