### PR TITLE
perf(line): optimize streaming envelope aggregation

### DIFF
--- a/flexviz/trace/line.py
+++ b/flexviz/trace/line.py
@@ -190,7 +190,7 @@ def _streaming_envelope_plan(
         lo_lit = pl.lit(x_lo)
         bsz_lit = pl.lit(bsz)
 
-        x, y = pl.col(x_col), pl.col(y_col)
+        y = pl.col(y_col)
         result = (
             src.group_by(
                 # True division lands x_hi exactly on n_out; fold that lone
@@ -201,10 +201,8 @@ def _streaming_envelope_plan(
                 .alias("__b")
             )
             .agg(
-                y.min().alias("__lo"),
-                y.max().alias("__hi"),
-                x.min_by(y).alias("__xlo"),
-                x.max_by(y).alias("__xhi"),
+                pl.col([x_col, y_col]).min_by(y).name.prefix("__lo_"),
+                pl.col([x_col, y_col]).max_by(y).name.prefix("__hi_"),
             )
             .collect(engine="streaming")
         )
@@ -215,16 +213,16 @@ def _streaming_envelope_plan(
         pts = pl.concat(
             [
                 result.select(
-                    pl.col("__xlo").alias("__x"),
-                    pl.col("__lo").alias("__y"),
+                    pl.col(f"__lo_{x_col}").alias("__x"),
+                    pl.col(f"__lo_{y_col}").alias("__y"),
                 ),
                 result.select(
-                    pl.col("__xhi").alias("__x"),
-                    pl.col("__hi").alias("__y"),
+                    pl.col(f"__hi_{x_col}").alias("__x"),
+                    pl.col(f"__hi_{y_col}").alias("__y"),
                 ),
             ]
         ).drop_nulls("__x")
-        pts = pts.unique(subset=["__x", "__y"]).sort("__x")
+        pts = pts.unique().sort("__x")
 
         return pts.select(
             pl.struct(

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -803,9 +803,9 @@ class TestPlotlyBrowser:
         _wait_for_init(page, "plotly")
 
         renders = page.evaluate("() => window.__renders")
-        assert len(renders) == 2, (
-            f"expected one data render per figure, got {len(renders)}: {renders}"
-        )
+        assert (
+            len(renders) == 2
+        ), f"expected one data render per figure, got {len(renders)}: {renders}"
 
     def test_saved_viewport_is_applied_on_open(self, page: Page, server_port: int):
         """A restored viewport must reach Plotly's axes.
@@ -818,13 +818,11 @@ class TestPlotlyBrowser:
         page.goto(url)
         _wait_for_init(page, "plotly")
 
-        applied = page.evaluate(
-            """() => {
+        applied = page.evaluate("""() => {
                 const gd = document.querySelector('.js-plotly-plot');
                 return gd && gd._fullLayout && gd._fullLayout.xaxis
                     ? gd._fullLayout.xaxis.range : null;
-            }"""
-        )
+            }""")
         assert applied is not None, "no Plotly x-axis found"
         assert applied[0] == pytest.approx(x_range[0], rel=1e-6), applied
         assert applied[1] == pytest.approx(x_range[1], rel=1e-6), applied


### PR DESCRIPTION
drop 2 expressions from the .agg for line ooc

-> slightly lower mem peak + slightly faster.

very small win, but cleaner code + less expressions to execute in parallel (will perhaps do more at many traces)