### PR TITLE
fix(skill): restore lost handoff guidance and document the API traps

### DIFF
--- a/docs/guides/ai-agents.md
+++ b/docs/guides/ai-agents.md
@@ -32,7 +32,8 @@ flexviz serve readings.parquet --cache --port 8077   # background server
 
 Each file becomes a source named by its stem. `--cache` enables cross-filter
 cubes and live brushing for files that do not change while serving. The
-server is ready when `GET /sources` answers.
+server is ready when `GET /sources` names your source. A bare "it answered"
+check is not enough, because another server can already own the port.
 
 The agent then builds a dashboard spec and mints a URL without opening a
 browser:

--- a/flexviz/skills/flexviz-explore/SKILL.md
+++ b/flexviz/skills/flexviz-explore/SKILL.md
@@ -46,6 +46,9 @@ zoomed and selected.
 flexviz schema data.parquet
 ```
 
+If `flexviz` is not on PATH, look for a project venv. Run `.venv/bin/flexviz`
+or `uv run flexviz`, and keep that form in every command that follows.
+
 Stable JSON: file, source name, columns with dtypes. Pick an x column
 (usually time) and the numeric/categorical columns worth plotting. A
 `.head(5).collect()` peek in Polars is fine; never collect the full frame.
@@ -59,15 +62,38 @@ flexviz serve data.parquet --cache --port 8077
 - Each file becomes a source named by its stem (`data.parquet` -> `"data"`).
 - `--cache` enables cross-filter cubes and live brushing. Use it whenever
   the file will not change while serving.
-- Wait for readiness: poll `curl -s http://127.0.0.1:8077/sources` until it
-  answers with the source list.
-- Keep the process running while the human explores; stop it when the
-  session is done.
+- Wait for readiness: poll until the answer names YOUR source, for example
+  `until curl -s http://127.0.0.1:8077/sources | grep -q '"data"'; do sleep 1; done`.
+  A bare "it answered" check is not enough. Another server can already own
+  the port and answer with its own source list.
+- If the port is busy, `flexviz serve` exits with `cannot bind ...`. Read the
+  serve log, then retry on a free port.
+- Keep the process running while the human explores. Tell them the port and
+  the PID. Stop the server when the session is done. A one-shot run
+  otherwise leaves an orphan server that holds the port.
 - To add files later, restart with the FULL file list (old + new), same
   port. URLs stay valid only while a server at the same address serves the
   same source names.
 - Serve on loopback. Binding another interface exposes unauthenticated
   endpoints; only do it if the human explicitly accepts that.
+
+`flexviz serve` scans the file as stored and cannot cast a column. Read the
+dtypes from step 1. A timestamp held as `String` gives a string x axis, not a
+time axis, and nothing warns you. Register the source yourself instead:
+
+```python
+import polars as pl, uvicorn
+from flexviz.server import app, register_source
+
+lf = pl.scan_parquet("data.parquet").with_columns(
+    pl.col("timestamp").str.to_datetime()
+)
+register_source("data", lf, cache=True)   # call this before uvicorn.run
+uvicorn.run(app, host="127.0.0.1", port=8077)
+```
+
+Then build step 3 on that same cast LazyFrame. If the spec and the registered
+source disagree about dtypes, the figures are wrong.
 
 ### 3. Build the dashboard and mint the URL
 
@@ -85,13 +111,18 @@ print(dash.share_url(server_url="http://127.0.0.1:8077", source_name="data"))
   The serve process answers all interactions.
 - `source_name` must match the served stem; `cache=True` must match
   `--cache`.
+- Give the human the complete URL in your reply. Never truncate it and
+  never write "see above". The URL is the only thing they can click.
 - No categorical column to `group_by`? Split related metrics across
   figures instead (one figure per metric family), and consider
   `add_corr_heatmap` or `add_histogram2d` to surface relationships
   between the numeric columns.
 
-API cheat-sheet — write calls from this, do not read the source
-(defaults shown; full reference: https://docs.flexviz.tech):
+API cheat-sheet (defaults shown; full reference: https://docs.flexviz.tech).
+The `#` notes mark the arguments whose meaning you cannot read off the
+signature. Those are where a call runs cleanly and charts the wrong thing, so
+read them before you write the call. For a detail that is not here, the
+docstrings in `flexviz/figure.py` are the source of truth:
 
 ```python
 Dashboard(data, cache=False)     # data: pl.LazyFrame/DataFrame, pandas, pyarrow
@@ -104,15 +135,28 @@ fig.add_line(x, y, name=None, color=None, n_points=1000,
              assume_sorted_x=False, group_by=None)
 fig.add_histogram(x=None, y=None, bins=20, histnorm="count",
                   name=None, group_by=None)
-fig.add_bar(labels, values=None,
-            agg="sum",                     # "mean"|"median"|"min"|"max"|"n_unique"
+fig.add_bar(labels, values=None,           # values=None counts rows per label
+            agg="sum",                     # "mean"|"median"|"min"|"max"|"n_unique";
+                                           #   ignored while values is None
             orientation="v", bar_mode="group", group_by=None)
 fig.add_boxplot(x=None, y=None, name=None, group_by=None)
-fig.add_pie(labels, values=None, agg="sum", hole=0.0)
-fig.add_treemap(path=[...], values=None, agg="sum")   # path: hierarchy columns
-fig.add_histogram2d(x, y, x_bins=20, y_bins=20, z=None, histfunc=None)
+fig.add_pie(labels, values=None, agg="sum", hole=0.0)  # values=None counts rows
+fig.add_treemap(path=[...], values=None, agg="sum")   # path: hierarchy columns;
+                                                      #   values=None counts rows
+fig.add_histogram2d(x, y, x_bins=20, y_bins=20,
+                    z=None, histfunc=None)   # z and histfunc are a pair: pass
+                                             #   both or neither. Either one on
+                                             #   its own raises. No z counts
+                                             #   rows per cell.
 fig.add_corr_heatmap(columns=None, method="pearson", triangular=False)
-fig.add_geo_histogram2d(lat, lon, lat_bins=64, lon_bins=64, z=None)
+fig.add_geo_histogram2d(lat, lon, lat_bins=64, lon_bins=64,
+                        z=None, histfunc=None,  # same pair rule as above
+                        bin_boundaries="data")
+# bin_boundaries picks what the bin grid is anchored to, and the default is
+#   often wrong. "data" spans the full data extent, so a handful of far-out
+#   points push every real point into one cell. "viewport" anchors the grid to
+#   the map bounds instead. Read the lat/lon min and max first, and pass
+#   "viewport" when the extent is much wider than the region you care about.
 fig.add_geo_line(lat, lon, n_points=1000)
 
 fig.title(text); fig.xlabel(text); fig.ylabel(text); fig.legend(show=True)
@@ -161,5 +205,6 @@ compute statistics on exactly what the human pointed at.
   stays in the lazy engine.
 - Read state through `flexvizState()` or `flexviz decode`; do not
   screenshot the dashboard to "see" it. The spec is exact, pixels are not.
-- One serve process per port. Pick an uncommon port (e.g. 8077) to avoid
-  colliding with the user's own servers.
+- One serve process per port. Pick an uncommon port (for example 8077).
+  Make sure that the port is free: your own earlier flexviz sessions are
+  the most likely occupant.


### PR DESCRIPTION
Two eval rounds on a 1M-row Parquet file, with fresh Sonnet and Haiku agents, exposed guidance the skill was missing.

The PATH, readiness-poll, port and full-URL fixes were written on 2026-08-28 but stayed on an unmerged branch, so no release carried them. The agents hit all four again. Both Sonnet runs spent a turn finding the project venv. One Haiku run polled a port that another server already owned, passed the readiness check, and returned a URL for a server it did not start.

The API cheat-sheet gave signatures without semantics, which broke the two models in opposite ways. Haiku wrote add_bar(labels=..., values=..., agg="n_unique"), charted unique values per label instead of row counts, and reported no friction. Both Sonnet runs drafted the same wrong call and escaped it only by ignoring the "do not read the source" line. That line punished the model that obeyed it, so it is removed. The traps are now annotated: values=None counts rows on bar, pie and treemap; z and histfunc must be passed together or not at all; bin_boundaries decides whether far-out points squash the map.

flexviz serve scans a file as stored and cannot cast a column, so a timestamp held as String gives a string x axis with no warning. Document the register_source escape hatch, and that step 3 must build on the same cast frame.

Re-running the failing Haiku case against this version yields agg="count" in the decoded spec and a cast datetime axis, at the same token cost.