### PR TITLE
feat(skill): add user-scope install and a plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "flex-analytics",
+  "owner": {
+    "name": "Flex Analytics",
+    "url": "https://github.com/flex-analytics"
+  },
+  "description": "FlexViz plugins for coding agents.",
+  "plugins": [
+    {
+      "name": "flexviz",
+      "source": "./",
+      "description": "Explore large local Parquet/CSV files as live interactive dashboards, and read back the zooms and selections the human makes."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "flexviz",
   "displayName": "FlexViz",
+  "version": "0.1.0b2",
   "description": "Explore large local Parquet/CSV files as live interactive dashboards, and read back the zooms and selections the human makes.",
   "author": {
     "name": "Flex Analytics",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "flexviz",
+  "displayName": "FlexViz",
+  "description": "Explore large local Parquet/CSV files as live interactive dashboards, and read back the zooms and selections the human makes.",
+  "author": {
+    "name": "Flex Analytics",
+    "url": "https://github.com/flex-analytics"
+  },
+  "homepage": "https://flexviz.tech",
+  "repository": "https://github.com/flex-analytics/flexviz",
+  "license": "Apache-2.0",
+  "keywords": ["data", "visualization", "parquet", "polars", "dashboard", "cross-filter"],
+  "skills": "./flexviz/skills/"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build sdist and wheel
         run: uv build --out-dir dist
 
-      - name: Artifacts match the tag
+      - name: Artifacts and the plugin manifest match the tag
         run: |
           version="${GITHUB_REF_NAME#v}"
           for expected in "dist/flexviz-${version}.tar.gz" "dist/flexviz-${version}-py3-none-any.whl"; do
@@ -63,6 +63,13 @@ jobs:
               exit 1
             fi
           done
+          # pyproject.toml owns the version. This keeps the copy the Claude Code
+          # marketplace serves from drifting behind it.
+          plugin=$(jq -r .version .claude-plugin/plugin.json)
+          if [ "$plugin" != "$version" ]; then
+            echo "::error::.claude-plugin/plugin.json says ${plugin}, tag says ${version}"
+            exit 1
+          fi
 
       # The last automated thing standing between the private working notes and
       # a permanent public upload. An allowlist, so a new private file at the

--- a/README.md
+++ b/README.md
@@ -104,7 +104,16 @@ The wheel ships an [Agent Skill](https://agentskills.io) that teaches your
 agent the workflow:
 
 ```bash
-flexviz skill install   # writes SKILL.md into .agents/skills/ and .claude/skills/
+flexviz skill install          # into .agents/skills/ and .claude/skills/
+flexviz skill install --user   # or once under $HOME, for every project
+```
+
+Claude Code can install the skill as a plugin instead, before the package is
+in the project:
+
+```
+/plugin marketplace add flex-analytics/flexviz
+/plugin install flexviz@flex-analytics
 ```
 
 Then ask it to explore `readings.parquet`. It reads the schema, serves the

--- a/docs/guides/ai-agents.md
+++ b/docs/guides/ai-agents.md
@@ -23,6 +23,28 @@ This writes `SKILL.md` into `.agents/skills/` (the cross-agent convention,
 read by Codex and others) and `.claude/skills/` (Claude Code). After that,
 asking your agent to "explore readings.parquet" triggers the workflow below.
 
+To install the skill once for every project, use `--user`:
+
+```bash
+flexviz skill install --user
+```
+
+This writes the same two directories under your home directory. Agents read
+personal skills in all projects, so you do not repeat the install. An
+existing file with different content is kept unless you add `--force`.
+
+## Install as a Claude Code plugin
+
+Claude Code can install the skill from the FlexViz marketplace, before the
+package is in the project:
+
+```
+/plugin marketplace add flex-analytics/flexviz
+/plugin install flexviz@flex-analytics
+```
+
+The skill then asks to install the `flexviz` package when a task needs it.
+
 ## What the agent does
 
 ```bash

--- a/flexviz/cli.py
+++ b/flexviz/cli.py
@@ -122,8 +122,10 @@ _SKILL_TARGET_DIRS = (".agents/skills", ".claude/skills")
 def _cmd_skill(args: argparse.Namespace) -> None:
     """Copy the packaged agent skill into a project's skill directories.
 
-    ``.agents/skills`` is the cross-agent repository convention (Codex and
-    friends); ``.claude/skills`` is Claude Code's project location.
+    ``.agents/skills`` is the cross-agent convention (Codex and friends);
+    ``.claude/skills`` is Claude Code's location. Both names hold project
+    skills under a project root and, with ``--user``, personal skills under
+    ``$HOME`` for every project.
     A destination file with different content is refused unless ``--force``
     is given, so user customizations survive reinstalls.
     """
@@ -132,7 +134,7 @@ def _cmd_skill(args: argparse.Namespace) -> None:
     content = (files("flexviz") / "skills" / _SKILL_NAME / "SKILL.md").read_text(
         encoding="utf-8"
     )
-    base = Path(args.dir)
+    base = Path.home() if args.user else Path(args.dir)
     refused: list[Path] = []
     for target in _SKILL_TARGET_DIRS:
         dest = base / target / _SKILL_NAME / "SKILL.md"
@@ -207,10 +209,16 @@ def main(argv: list[str] | None = None) -> None:
 
     skill = sub.add_parser("skill", help="manage the flexviz-explore agent skill")
     skill.add_argument("action", choices=["install"])
-    skill.add_argument(
+    scope = skill.add_mutually_exclusive_group()
+    scope.add_argument(
         "--dir",
         default=".",
         help="project root to install into (default: current directory)",
+    )
+    scope.add_argument(
+        "--user",
+        action="store_true",
+        help="install into $HOME instead, for use in every project",
     )
     skill.add_argument(
         "--force",

--- a/flexviz/skills/flexviz-explore/SKILL.md
+++ b/flexviz/skills/flexviz-explore/SKILL.md
@@ -47,7 +47,9 @@ flexviz schema data.parquet
 ```
 
 If `flexviz` is not on PATH, look for a project venv. Run `.venv/bin/flexviz`
-or `uv run flexviz`, and keep that form in every command that follows.
+or `uv run flexviz`, and keep that form in every command that follows. If the
+package is absent, ask the human before you install it (`uv add flexviz`, or
+`pip install flexviz`).
 
 Stable JSON: file, source name, columns with dtypes. Pick an x column
 (usually time) and the numeric/categorical columns worth plotting. A

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """CLI and share_url tests: URL round-trip, file registration, error paths."""
 
 import json
+from pathlib import Path
 
 import polars as pl
 import pytest
@@ -214,3 +215,16 @@ def test_serve_fails_fast_on_busy_port(tmp_path):
         proc = _run_module("serve", str(path), "--port", str(port))
         assert proc.returncode != 0
         assert "cannot bind" in proc.stderr
+
+
+def test_skill_install_user_scope(capsys, monkeypatch, tmp_path):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    main(["skill", "install", "--user"])
+    for skill in _skill_paths(tmp_path):
+        assert skill.exists(), skill
+    assert capsys.readouterr().out.count("installed") == 2
+
+
+def test_skill_install_scope_flags_are_exclusive():
+    with pytest.raises(SystemExit):
+        main(["skill", "install", "--user", "--dir", "."])


### PR DESCRIPTION
`flexviz skill install --user` writes the skill under $HOME instead of a project root, so agents find it in every project without a repeat install.
`--dir` and `--user` are mutually exclusive.

`.claude-plugin/marketplace.json` makes the repository a plugin marketplace for Claude Code users, who then get the skill before they install the package. The plugin is the repository itself, and `plugin.json` points `skills` at the packaged `flexviz/skills/`, so no second copy of SKILL.md can drift from the wheel. Because the agent can now hold the skill before the package exists, step 1 of SKILL.md tells it to ask before it installs `flexviz`.